### PR TITLE
Add use strict statement

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const fs = require('fs')
 const path = require('path')
 const chalk = require('chalk')


### PR DESCRIPTION
Without `'use strict'` statement, an error with gulp-eslint occurs
